### PR TITLE
[BUGFIX] Create symlink to support /usr/bin/php (fix #1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ RUN git clone https://github.com/zendtech/ZendOptimizerPlus /tmp/ZendOptimizerPl
 	&& cd / \
 	&& rm -rf /tmp/ZendOptimizerPlus
 
+# create symlink to support standard /usr/bin/php
+ln -s /usr/local/bin/php /usr/bin/php
+
 # locales
 ADD assets/locale.gen /etc/locale.gen
 RUN apt-get update \


### PR DESCRIPTION
The default path for php is /usr/bin/php. Some TYPO3 extensions and
TYPO3 itself look for php in this path. By creating a symlink we support
this default path without the need to reconfigure TYPO3.